### PR TITLE
Fix Typo in `http.go`

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -274,7 +274,7 @@ func (s *Service) get(ctx context.Context,
 		case errors.Is(err, context.DeadlineExceeded):
 			// We don't consider context deadline exceeded to be a potential connection issue, as the user selected the deadline.
 		case strings.HasSuffix(callURL.String(), "/node/syncing"):
-			// Special case; if we have called the syncing endpoint and it failed then we don't check the connectino status, as
+			// Special case; if we have called the syncing endpoint and it failed then we don't check the connection status, as
 			// that calls the syncing endpoint itself and so we find ourselves in an endless loop.
 		default:
 			// We consider other errors to be potential connection issues.


### PR DESCRIPTION
# Pull Request Title
Fix Typo in `http.go`

## Description
This pull request fixes a typo in the `http.go` file to improve readability and clarity in the code comments.

### Changes Made:
- **File Modified:** `http/http.go`
- **Summary of Changes:**  
  - Line 274: Replaced "connectino" with "connection" in the comment.

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] The change adheres to the [GitHub Community Guidelines](link-to-guidelines).
- [x] Documentation comments have been corrected for improved clarity.
- [x] No functional code changes were made.

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Comment update only)

## Additional Notes
This is a minor documentation update. No functional changes have been made. If further adjustments are required, please let me know.

---

**Allow edits by maintainers:** [x]
<!-- Check this box to allow maintainers to modify the pull request if needed. -->
