### PR TITLE
**Fix Typo in `signedvalidatorregistration_test.go`**

### DIFF
--- a/api/v1/signedvalidatorregistration_test.go
+++ b/api/v1/signedvalidatorregistration_test.go
@@ -66,7 +66,7 @@ func TestSignedValidatorRegistrationJSON(t *testing.T) {
 		},
 		{
 			name:  "SignatureInvalid",
-			input: []byte(`{"message":{"fee_recipient":"0x000102030405060708090a0b0c0d0e0f10111213","gas_limit":"100","timestamp":"100","pubkey":"0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f"},"signature":"invlaid"}`),
+			input: []byte(`{"message":{"fee_recipient":"0x000102030405060708090a0b0c0d0e0f10111213","gas_limit":"100","timestamp":"100","pubkey":"0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f"},"signature":"invalid"}`),
 			err:   "invalid value for signature: encoding/hex: invalid byte: U+0069 'i'",
 		},
 		{


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `signedvalidatorregistration_test.go`**

## Description  
This pull request corrects a typo in the `signedvalidatorregistration_test.go` file.

### Changes Made:
- **File Modified:** `signedvalidatorregistration_test.go`
- **Summary of Changes:**  
  - Corrected the typo in the `signature` field from `"invlaid"` to `"invalid"` in the test case.

## Checklist  
- [x] Corrected the typo in the test case.
- [x] Verified that the test is correct after the fix.

## Additional Notes  
This change ensures the test runs correctly by fixing the typo in the test input.

---

**Allow edits by maintainers:** [x]
